### PR TITLE
feat: improve the recipe of release-notes generation

### DIFF
--- a/api-doc-gen/recipes/release-notes.ts
+++ b/api-doc-gen/recipes/release-notes.ts
@@ -8,7 +8,7 @@ if (!start || !end) {
 
 const cwd = tmpdir();
 
-console.log(`Retrieving issues between ${start}and ${end}...`)
+console.log(`Retrieving issues between ${start} and ${end}...`)
 // Get list of commit logs containing '#' between the two tags and extract unique issue numbers
 const issue_numbers = await exec(`git log ${start}..${end} --oneline | grep -o '#[0-9]\\+' | sed 's/#//' | sort -u`) as string;
 
@@ -19,7 +19,9 @@ for (const issue of issue_numbers.trim().split("\n")) {
 }
 
 console.log("Generating diff");
-await exec(`git diff --submodule=diff ${start}...${end} > ${cwd}/range_diff.txt`)
+// We use git-log to get authors, commit messages and code diff.
+// We use --submodule=diff to include submodule changes
+await exec(`git log --submodule=diff --patch ${start}...${end} > ${cwd}/range_diff.txt`)
 copy(`${cwd}/range_diff.txt`, "range_diff.txt");
 
 export default {

--- a/api-doc-gen/recipes/release-notes.ts
+++ b/api-doc-gen/recipes/release-notes.ts
@@ -14,12 +14,12 @@ const referenceIds = await exec(`git log ${start}..${end} --oneline | grep -o '#
 
 for (const reference of referenceIds.trim().split("\n")) {
     console.log(`Processing reference #${reference}`)
-    try {
-        const content = await exec(`gh pr view ${reference}`) as string;
+    let content = await exec(`gh pr view ${reference}`) as string;
+    if (content) {
         copyText(content, `pull_requests/${reference}.txt`);
-    } catch (e) {
-        console.debug(`Failed to get content as pull-request for #${reference}, trying as issue`, e);
-        const content = await exec(`gh issue view ${reference}`) as string;
+    } else {
+        console.debug(`Failed to get content as pull-request for #${reference}, trying as issue`);
+        content = await exec(`gh issue view ${reference}`) as string;
         copyText(content, `issues/${reference}.txt`);
     }
 }


### PR DESCRIPTION
## Description

This PR improves the recipe of release-note generation by:

* Distinguishing the issues and pull-requests. Although their structures look similar, but their metadata are fundamentally different: the issues are usually created by product owner, while pull-requests are opened by developers. The issues contain labels and associated to a GitHub project. The pull-requests do not contain labels and is not associated with a project.
* Include commits into the diff.  In some cases, commits are not linked to a pull-request, but linked to an issue (direct pushes). We lose information in this case.

This is related to https://github.com/becomposable/studio/issues/490

## Testing

Tested locally by generating a memory pack and inspect the generated tar, which contains both pull-requests and issues.