### PR TITLE
Improve data collection for release notes generation

### DIFF
--- a/api-doc-gen/recipes/release-notes.ts
+++ b/api-doc-gen/recipes/release-notes.ts
@@ -11,10 +11,10 @@ const cwd = tmpdir();
 console.log(`Retrieving issues between ${start} and ${end}...`)
 
 // Get GitHub reference IDs (issue or pull-request) from commit messages
-// Commits having the hashtag
+// Commits having the hashtag, like "Fix #123" => 123
 const hashtagIds = await exec(`git log ${start}..${end} --oneline | grep -o -E '#[0-9]+' | sed 's/#//'`) as string;
-// Commits with patterns like "fix(123) ..." or "feat(123) ..."
-const patternIds = await exec(`git log ${start}..${end} --oneline | grep -o -E '\\([0-9]+\\)'`) as string;
+// Commits with patterns like "fix(456) ..." or "feat(456) ..." => 456
+const patternIds = await exec(`git log ${start}..${end} --oneline | grep -o -E '\\([0-9]+\\)' | sed 's/[()]//g'`) as string;
 
 const unsortedReferenceIds = new Set(`${hashtagIds}\n${patternIds}`.trim().split("\n").map(v => v.trim()).map(Number));
 const referenceIds = Array.from(unsortedReferenceIds).sort((a, b) => a - b);

--- a/api-doc-gen/recipes/release-notes.ts
+++ b/api-doc-gen/recipes/release-notes.ts
@@ -12,9 +12,9 @@ console.log(`Retrieving issues between ${start} and ${end}...`)
 
 // Get GitHub reference IDs (issue or pull-request) from commit messages
 // Commits having the hashtag
-const hashtagIds = await exec(`git log ${start}..${end} --oneline | grep -o '#[0-9]+' | sed 's/#//'`) as string;
+const hashtagIds = await exec(`git log ${start}..${end} --oneline | grep -o -E '#[0-9]+' | sed 's/#//'`) as string;
 // Commits with patterns like "fix(123) ..." or "feat(123) ..."
-const patternIds = await exec(`git log ${start}..${end} --oneline | grep -o '\\([0-9]+\\)'`) as string;
+const patternIds = await exec(`git log ${start}..${end} --oneline | grep -o -E '\\([0-9]+\\)'`) as string;
 
 const unsortedReferenceIds = new Set(`${hashtagIds}\n${patternIds}`.trim().split("\n").map(v => v.trim()).map(Number));
 const referenceIds = Array.from(unsortedReferenceIds).sort((a, b) => a - b);


### PR DESCRIPTION
This PR improves the data collection for release notes generation, including:

* Support patterns like fix(123) and feat(123)
* Make commands compatible with macOS (GNU grep and BSD grep)
* Accept issues from milestone